### PR TITLE
Fix "high schooler" in welcome-committee message

### DIFF
--- a/interactions/post-welcome-committee.js
+++ b/interactions/post-welcome-committee.js
@@ -13,7 +13,7 @@ async function postWelcomeCommittee(user) {
     const message =
       invite?.['welcome_message'] || "I'm using the /toriel-restart command"
     const continent = invite?.['continent'] || 'DEFAULT_CONTINENT'
-    const hs = invite?.['high_school'] || true
+    const hs = invite ? invite.high_school : true
     await client.chat.postMessage({
       channel: transcript('channels.welcome-committee'),
       text: transcript('welcome-committee', {

--- a/util/transcript.yml
+++ b/util/transcript.yml
@@ -93,7 +93,7 @@ house:
   leave: I understand you want to leave the house to venture into town. Are you sure you really want to continue, my child?
 
 welcome-committee: |
-  <@${this.user}> (${this.hs && 'a high schooler '}in ${this.continent.toLowerCase()}) just became a full user in the Slack! Here's why they joined:
+  <@${this.user}> (${this.hs ? 'a high schooler' : 'an adult'} in ${this.continent.toLowerCase()}) just became a full user in the Slack! Here's why they joined:
   ${this.message.split('\n').map(line => '> '+line)}
 
 command:


### PR DESCRIPTION
Currently all the welcome-committee messages for new members say "high schooler" because it [always defaults to true](https://github.com/hackclub/toriel/blob/4f6869bb884019f2ec99fb27aad8fb613b5a3652/interactions/post-welcome-committee.js#L16).

This PR fixes that, so if the new member is not a teenager, the welcome-committee message will reflect that.