### PR TITLE
React to this message to take ownership on reaching out.

### DIFF
--- a/util/transcript.yml
+++ b/util/transcript.yml
@@ -128,6 +128,7 @@ club-leader:
 welcome-committee: |
   <@${this.user}> (${this.hs ? 'a high schooler' : 'an adult'} in ${this.continent.toLowerCase()}) just became a full user in the Slack! Here's why they joined:
   ${this.message.split('\n').map(line => '> '+line)}
+  React to this message to take ownership on reaching out.
 
 command:
   not-found: i'm not sure how to do that, my child. (slash command not found)


### PR DESCRIPTION
Members of #welcome-committee post-clippy aren't familiar with the old "React to this message to take ownership on reaching out" procedure being used. This PR adds that line to clarify. 

Many people have joined the Slack in the past couple days :wahoo-fish: