### PR TITLE
Replace waiting room with shaded spot under a large tree

### DIFF
--- a/setup/cave-channel.js
+++ b/setup/cave-channel.js
@@ -30,7 +30,7 @@ async function postMessage() {
     blocks: [
       transcript('block.text', { text: transcript('cave-intro') }),
       transcript('block.single-button', {
-        text: 'Start',
+        text: 'Explore the cave',
         value: 'cave_start',
       }),
     ],

--- a/util/invite-types/default.js
+++ b/util/invite-types/default.js
@@ -1,7 +1,7 @@
 const { transcript } = require('../transcript')
 
 const defaultInvite = {
-  channels: [transcript('channels.cave')],
+  channels: [transcript('channels.cave'), transcript('channels.shaded-spot-under-a-large-tree')],
   customMessage: 'While wandering through a forest, you stumble upon a cave...',
 }
 

--- a/util/invite-types/default.js
+++ b/util/invite-types/default.js
@@ -1,7 +1,10 @@
 const { transcript } = require('../transcript')
 
 const defaultInvite = {
-  channels: [transcript('channels.cave'), transcript('channels.shaded-spot-under-a-large-tree')],
+  channels: [
+    transcript('channels.cave'),
+    transcript('channels.shaded-spot-under-a-large-tree'),
+  ],
   customMessage: 'While wandering through a forest, you stumble upon a cave...',
 }
 

--- a/util/invite-types/hcb.js
+++ b/util/invite-types/hcb.js
@@ -1,7 +1,10 @@
 const { transcript } = require('../transcript')
 
 const hcbInvite = {
-  channels: [transcript('channels.bank'), transcript('channels.shaded-spot-under-a-large-tree')],
+  channels: [
+    transcript('channels.bank'),
+    transcript('channels.shaded-spot-under-a-large-tree'),
+  ],
   customMessage: 'While wandering through a forest, you stumble upon a cave...',
 }
 

--- a/util/invite-types/hcb.js
+++ b/util/invite-types/hcb.js
@@ -1,7 +1,7 @@
 const { transcript } = require('../transcript')
 
 const hcbInvite = {
-  channels: [transcript('channels.bank')],
+  channels: [transcript('channels.bank'), transcript('channels.shaded-spot-under-a-large-tree')],
   customMessage: 'While wandering through a forest, you stumble upon a cave...',
 }
 

--- a/util/invite-types/onboard.js
+++ b/util/invite-types/onboard.js
@@ -1,7 +1,11 @@
 const { transcript } = require('../transcript')
 
 const onboardInvite = {
-  channels: [transcript('channels.onboard'), transcript('channels.cave'), transcript('channels.shaded-spot-under-a-large-tree')],
+  channels: [
+    transcript('channels.onboard'),
+    transcript('channels.cave'),
+    transcript('channels.shaded-spot-under-a-large-tree'),
+  ],
   customMessage: 'Welcome onboard!',
 }
 

--- a/util/invite-types/onboard.js
+++ b/util/invite-types/onboard.js
@@ -1,7 +1,7 @@
 const { transcript } = require('../transcript')
 
 const onboardInvite = {
-  channels: [transcript('channels.onboard'), transcript('channels.cave')],
+  channels: [transcript('channels.onboard'), transcript('channels.cave'), transcript('channels.shaded-spot-under-a-large-tree')],
   customMessage: 'Welcome onboard!',
 }
 

--- a/util/transcript.yml
+++ b/util/transcript.yml
@@ -93,7 +93,7 @@ announcements-to-cave: hello wanderer! head to <#${this.t('channels.cave')}> to 
 
 cave-intro: |
   while wandering through the forest, you've stumbled down the entrance of a cave. it looks too high to climb back out.
-  You also find a note asking you walk over to a <#${this.t('channels.shaded-spot-under-a-large-tree')} if you need help!
+  You spot a hand-drawn note pinned to a tree root: NEED HELP? GO TO THE <#${this.t('channels.shaded-spot-under-a-large-tree')} IF YOU NEED HELP!
 
 cave-join: |
   oh hello... i don't think i recognize you; you must be new in town.

--- a/util/transcript.yml
+++ b/util/transcript.yml
@@ -35,7 +35,6 @@ channels:
   leaders: C02PA5G01ND
   music: C0DCUUH7E
   neighbourhood: C01AS1YEM8A
-  waiting-room: C065BEE8NUA
   pasture: C01PF39CVAS
   poll-of-the-day: C01U8UCHZC1
   question-of-the-day: C013AGZKYCS
@@ -56,6 +55,7 @@ channels:
   outernet: C054FA87K8C
   onboard: C056AMWSFKJ
   happenings: C05B6DBN802
+  shaded-spot-under-a-large-tree: C065BEE8NUA
 
 block:
   text:
@@ -93,8 +93,7 @@ announcements-to-cave: hello wanderer! head to <#${this.t('channels.cave')}> to 
 
 cave-intro: |
   while wandering through the forest, you've stumbled down the entrance of a cave. it looks too high to climb back out.
-  You also find a note asking you to post in #waiting-room if you need help!
-
+  You also find a note asking you walk over to a <#${this.t('channels.shaded-spot-under-a-large-tree')} if you need help!
 
 cave-join: |
   oh hello... i don't think i recognize you; you must be new in town.


### PR DESCRIPTION
Fixes https://github.com/hackclub/toriel/issues/190

Instead of #base-of-a-tree, this uses #shaded-area-under-a-large-tree. We need a channel name that shows up later in alphabetical order than #click-me-to-get-started because Slack will list channels in alphabetical order and users could be confused by starting in the help channel first.
<img width="690" alt="Screenshot 2024-01-18 at 16 12 02" src="https://github.com/hackclub/toriel/assets/5891442/3ac93181-644c-42a6-895b-20161fedc987">

This PR merging and deploying won't cause the updated copy in the channel, it needs to be run manually in development or prod with this code https://github.com/hackclub/toriel/blob/8eccc47cde076a9179490dc4a7e54ce8131884e3/index.js#L345