### PR TITLE
Configure timing of help message scheduling

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const { prisma } = require('./db')
 const { metrics } = require('./util/metrics')
 const { upgradeUser } = require('./util/upgrade-user.js')
 const { destroyHelpMeMessage } = require('./util/notify-channel.js')
+const { scheduleHelpMeMessage } = require('../util/notify-channel')
 
 receiver.router.use(express.json())
 
@@ -109,6 +110,13 @@ app.event('message', async (args) => {
       .catch((e) => {
         console.warn(e)
       })
+    mirrorMessage({
+      message: `<@${user}> has been dropped into cave`,
+      user,
+      channel,
+      type,
+    })
+    scheduleHelpMeMessage(client, user)
   } // delete "user has joined" message if it is sent in one of the default channels that TORIEL adds new members to
 })
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const { prisma } = require('./db')
 const { metrics } = require('./util/metrics')
 const { upgradeUser } = require('./util/upgrade-user.js')
 const { destroyHelpMeMessage } = require('./util/notify-channel.js')
-const { scheduleHelpMeMessage } = require('../util/notify-channel')
+const { scheduleHelpMeMessage } = require('./util/notify-channel')
 
 receiver.router.use(express.json())
 

--- a/interactions/join-cave.js
+++ b/interactions/join-cave.js
@@ -3,7 +3,6 @@ const { sleep } = require('../util/sleep')
 const { transcript } = require('../util/transcript')
 const { prisma } = require('../db')
 const { getEmailFromUser } = require('../util/get-invite')
-const { scheduleHelpMeMessage } = require('../util/notify-channel')
 
 async function joinCaveInteraction(args) {
   const { client, payload } = args
@@ -28,8 +27,6 @@ async function joinCaveInteraction(args) {
       toriel_stage: 'STARTED_FLOW',
     },
   })
-
-  await scheduleHelpMeMessage(client, user)
 
   await Promise.all([
     client.chat.postEphemeral({

--- a/interactions/startup.js
+++ b/interactions/startup.js
@@ -7,9 +7,12 @@ function getEnv() {
 }
 function getVersion() {
   // https://devcenter.heroku.com/articles/dyno-metadata
-  const versionData = [process.env.HEROKU_RELEASE_VERSION, process.env.HEROKU_SLUG_COMMIT]
+  const versionData = [
+    process.env.HEROKU_RELEASE_VERSION,
+    process.env.HEROKU_SLUG_COMMIT,
+  ]
   if (versionData) {
-    return versionData.map(t => t.slice(0, 8)).join('-')
+    return versionData.map((t) => t.slice(0, 8)).join('-')
   } else {
     return 'local'
   }
@@ -20,7 +23,7 @@ async function startup() {
   await client.chat.postMessage({
     blocks: [
       transcript('block.text', { text: transcript('startup.message') }),
-      transcript('block.context', { text: `${getEnv()}-${getVersion()}` })
+      transcript('block.context', { text: `${getEnv()}-${getVersion()}` }),
     ],
     channel: transcript('channels.bot-spam'),
     username: 'TUTORIEL',

--- a/util/notify-channel.js
+++ b/util/notify-channel.js
@@ -4,6 +4,7 @@ const { transcript } = require('../util/transcript')
 async function scheduleHelpMeMessage(client, user_id) {
   const postDate = new Date()
   //6 hours into the future
+
   postDate.setTime(postDate.getTime() + 6 * 60 * 60 * 1000)
 
   const result = await client.chat.scheduleMessage({


### PR DESCRIPTION
Configured it so that help message is scheduled 6 hours after the user is dropped into the slack. Also, mirrored message to say that someone has been dropped in cave.

index.js
```js
  if (
    subtype === 'channel_join' &&
    text === `<@${user}> has joined the channel` &&
    defaultAddsId.includes(channel)
  ) {
    console.log('Deleting "user has joined" message')
    await client.chat
      .delete({
        token: process.env.SLACK_LEGACY_TOKEN, // sudo
        channel,
        ts,
      })
      .catch((e) => {
        console.warn(e)
      })
    mirrorMessage({
      message: `<@${user}> has been dropped into cave`,
      user,
      channel,
      type,
    })
    scheduleHelpMeMessage(client, user)
  } // delete "user has joined" message if it is sent in one of the default channels that TORIEL adds new members to
})
```